### PR TITLE
Configure gosteno logger with log level set from an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The nozzle can also be configured by setting a set of environment variables. The
 | PORT | WebServerPort |
 | BM_WEBSERVER_USE_SSL | WebServerUseSSL |
 | BM_STDOUT_LOGGING | Does not correspond to a config field, but signals if logging should save to files or straight to stdout. |
-
+| BM_LOG_LEVEL | Does not correspond to a config field, but allows you to configure the log level for the nozzle. See [gosteno](https://github.com/cloudfoundry/gosteno#level) for possible values. |
 
 ## SSL Certificates
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	stdOutLogging = "BM_STDOUT_LOGGING"
+	stdOutLogging  = "BM_STDOUT_LOGGING"
+	logLevelEnvVar = "BM_LOG_LEVEL"
 )
 
 //New logger
-func New(logDirectory string, logFile string, loggerName string) *gosteno.Logger {
+func New(logDirectory string, logFile string, loggerName string, logLevel string) *gosteno.Logger {
 	loggingConfig := &gosteno.Config{
 		Sinks:		 make([]gosteno.Sink, 1),
-		Level:     gosteno.LOG_DEBUG,
+		Level:     computeLevel(logLevel),
 		Codec:     gosteno.NewJsonCodec(),
 		EnableLOC: true,
 	}
@@ -75,4 +76,15 @@ func getAbsolutePath(logDirectory string) string {
 	}
 
 	return absolutelogDirectory
+}
+
+func computeLevel(name string) gosteno.LogLevel {
+	if envValue := os.Getenv(logLevelEnvVar); envValue != "" {
+		name = envValue
+	}
+	ll, err := gosteno.GetLogLevel(name)
+	if err != nil {
+		return gosteno.LOG_INFO
+	}
+	return ll
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -9,6 +9,7 @@ import (
     "fmt"
     "io/ioutil"
     "strings"
+    "github.com/cloudfoundry/gosteno"
 )
 
 const (
@@ -16,15 +17,16 @@ const (
     logFile = "bm_nozzle.log"
     testLog = "test log"
     loggerName = "bm_firehose_nozzle"
+    testLogLevel = "debug"
 )
 
 func TestLogDirectoryCreation(t *testing.T) {
     //Setup Envrionment
     setupEnvrionment(t)
-    
+
     CreateLogDirectory(logDirectory)
-    New(logDirectory, logFile, loggerName)
-    
+    New(logDirectory, logFile, loggerName, testLogLevel)
+
     //See if log file was created
     checkLogFileExists(t)
 }
@@ -32,13 +34,27 @@ func TestLogDirectoryCreation(t *testing.T) {
 func TestLogFileContents(t *testing.T) {
     //Setup Enivronment
     setupEnvrionment(t)
-    
+
     CreateLogDirectory(logDirectory)
-    logger := New(logDirectory, logFile, loggerName)
+    logger := New(logDirectory, logFile, loggerName, testLogLevel)
     logger.Info(testLog)
-    
+
     //Test if log contents contains test string
     checkLogContents(t)
+}
+
+func TestLogLevelOverride(t *testing.T) {
+    //Setup Envrionment
+    setupEnvrionment(t)
+    //Override level with env var
+    logLevel := "warn"
+    os.Setenv(logLevelEnvVar, logLevel)
+
+    CreateLogDirectory(logDirectory)
+    New(logDirectory, logFile, loggerName, testLogLevel)
+
+    //Test if log level is set from env
+    checkLogLevel(t, logLevel)
 }
 
 func setupEnvrionment(t *testing.T) {
@@ -61,11 +77,18 @@ func checkLogContents(t *testing.T) {
     if err != nil {
         t.Fatalf("Failed to load log file: %s", err)
     }
-    
+
     fileString := string(fileBuffer)
-    
+
     t.Logf("Checking log contents... (expecting log contains: %s)", testLog)
     if !strings.Contains(fileString, testLog) {
         t.Errorf("Expected log contents to contain %s, string was not in log", testLog)
+    }
+}
+
+func checkLogLevel(t *testing.T, logLevel string) {
+    t.Log("Check if log level set from env")
+    if l, _ := gosteno.GetLogLevel(logLevel); l != gosteno.LOG_WARN {
+        t.Fatalf("Log level was not set to warn")
     }
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ const (
 	defaultLogDirectory = "./logs"
 	nozzleLogFile       = "bm_nozzle.log"
 	nozzleLogName       = "bm_firehose_nozzle"
+	nozzleLogLevel      = "info"
 
 	webserverLogFile = "bm_server.log"
 	webserverLogName = "bm_server"
@@ -26,6 +27,7 @@ const (
 var (
 	//Mode to run nozzle in. Webserver mode is for debugging purposes only
 	runMode = flag.String("mode", "normal", "Mode to run nozzle `normal` or `webserver`")
+	logLevel = flag.String("log-level", nozzleLogLevel, "Set log level to control verbosity - defaults to info")
 )
 
 func main() {
@@ -41,7 +43,7 @@ func main() {
 func normalSetup() {
 	logger.CreateLogDirectory(defaultLogDirectory)
     
-	logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName)
+	logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName, *logLevel)
 	logger.Debug("working log")
 
 	//Read in config
@@ -62,7 +64,7 @@ func normalSetup() {
 }
 
 func standUpWebServer() {
-	logger := logger.New(defaultLogDirectory, webserverLogFile, webserverLogName)
+	logger := logger.New(defaultLogDirectory, webserverLogFile, webserverLogName, *logLevel)
     
     //Read in config
 	config, err := nozzleconfiguration.New(defaultConfigLocation, logger)
@@ -82,7 +84,7 @@ func standUpWebServer() {
 }
 
 func createWebServer(config *nozzleconfiguration.NozzleConfiguration) *webserver.WebServer {
-	logger := logger.New(defaultLogDirectory, webserverLogFile, webserverLogName)
+	logger := logger.New(defaultLogDirectory, webserverLogFile, webserverLogName, *logLevel)
 	return webserver.New(config, logger)
 }
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -17,3 +17,4 @@ applications:
     BM_METRIC_CACHE_DURATION_SECONDS: 90
     BM_WEBSERVER_USE_SSL: false
     BM_STDOUT_LOGGING: true
+    BM_LOG_LEVEL: info

--- a/nozzleconfiguration/nozzle_configuration_test.go
+++ b/nozzleconfiguration/nozzle_configuration_test.go
@@ -19,7 +19,8 @@ const (
     defaultLogDirectory = "../logs"
 	nozzleLogFile       = "bm_nozzle.log"
 	nozzleLogName       = "bm_firehose_nozzle"
-    
+    nozzleLogLevel      = "debug"
+
     configFile = "../config/bluemedora-firehose-nozzle.json"
     tempConfigFile = "../config/bluemedora-firehose-nozzle.json.real"
     
@@ -58,7 +59,7 @@ func TestConfigParsing(t *testing.T) {
     
     t.Log("Creating configuration...")
     logger.CreateLogDirectory(defaultLogDirectory)
-    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName)
+    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName, nozzleLogLevel)
     
     //Create new configuration
     var config *NozzleConfiguration
@@ -139,7 +140,7 @@ func TestBadConfigFile(t *testing.T) {
     }
     
     logger.CreateLogDirectory(defaultLogDirectory)
-    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName)
+    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName, nozzleLogLevel)
     
     //Create new configuration
     t.Log("Checking loading of bad config file... (expecting error)")
@@ -162,7 +163,7 @@ func TestBadConfigFile(t *testing.T) {
 func TestNoConfigFile(t *testing.T) {
     t.Log("Creating configuration...")
     logger.CreateLogDirectory(defaultLogDirectory)
-    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName)
+    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName, nozzleLogLevel)
     
     //Create new configuration
     t.Log("Checking loading of non-existent file... (expecting error)")
@@ -187,7 +188,7 @@ func TestEnvironmentVariables(t *testing.T) {
     
     t.Log("Creating configuration...")
     logger.CreateLogDirectory(defaultLogDirectory)
-    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName)
+    logger := logger.New(defaultLogDirectory, nozzleLogFile, nozzleLogName, nozzleLogLevel)
 
     os.Setenv(uaaURLEnv, testEnvUAAURL)
     os.Setenv(uaaUsernameEnv, testEnvUsername)

--- a/webserver/web_server_test.go
+++ b/webserver/web_server_test.go
@@ -22,8 +22,10 @@ const (
 	defaultLogDirectory = "../logs"
 	webserverLogFile    = "bm_server.log"
 	webserverLogName    = "bm_server"
-	
-	testCertLocation = "../certs/cert.pem"
+	webserverLogLevel   = "debug"
+
+
+testCertLocation = "../certs/cert.pem"
 	testKeyLocation  = "../certs/key.pem"
 )
 
@@ -558,7 +560,7 @@ func noCachedDataTest(t *testing.T, client *http.Client, token string, port uint
 func createWebServer(t *testing.T) (*WebServer, *nozzleconfiguration.NozzleConfiguration) {
 	t.Log("Creating webserver...")
 	logger.CreateLogDirectory(defaultLogDirectory)
-	logger := logger.New(defaultLogDirectory, webserverLogFile, webserverLogName)
+	logger := logger.New(defaultLogDirectory, webserverLogFile, webserverLogName, webserverLogLevel)
 
 	config, err := nozzleconfiguration.New(defaultConfigLocation, logger)
 	if err != nil {


### PR DESCRIPTION
Addresses issue #7. Lets users set the BM_LOG_LEVEL environment variable to override
the gosteno log level. If it's not set then it will default to "info".